### PR TITLE
Add functionality for status sub command

### DIFF
--- a/src/commands/gpio_status.rs
+++ b/src/commands/gpio_status.rs
@@ -1,0 +1,90 @@
+use options::GpioStatusOptions;
+use config::GpioConfig;
+use config::PinConfig;
+use sysfs_gpio::Direction;
+use std::process::exit;
+
+pub fn main(config: &GpioConfig, opts: &GpioStatusOptions) {
+    match opts.pin {
+        Some(ref pin_name) => {
+            let pin_config = match config.get_pin(&pin_name[..]) {
+                Some(pin) => pin,
+                None => {
+                    println!("Unable to find config entry for pin '{}'", pin_name);
+                    exit(1)
+                }
+            };
+            print_pin_header();
+            print_pin_row(&pin_config, true);
+        },
+        None => {
+            print_pin_header();
+            for (pos, pin) in config.get_pins().iter().enumerate() {
+                print_pin_row(pin, pos == (config.get_pins().len() - 1));
+            }
+        }
+    }
+}
+
+
+fn print_pin_header(){
+    println!("| {:<10} | {:<10} | {:<10} | {:<10} | {:<10} | {:<10} |", 
+             "Number", 
+             "Exported", 
+             "Direction",  
+             "Active Low", 
+             "Names", 
+             "Value");
+    print_row_sep(false);
+}
+
+fn print_row_sep(is_last: bool){
+    let col_sep = if is_last {"-"} else {"+"};
+    println!("{}{:->13}{:->13}{:->13}{:->13}{:->13}{:->13}", 
+             col_sep,
+             col_sep,
+             col_sep,
+             col_sep,
+             col_sep,
+             col_sep,
+             col_sep);
+}
+
+fn print_pin_row(pin_config: &PinConfig, is_last: bool){
+    let direction = match pin_config.direction {
+        Direction::In => "In",
+        Direction::Out => "Out",
+        Direction::High => "High",
+        Direction::Low => "Low",
+    };
+
+    let value = match pin_config.get_pin().get_value() {
+        Ok(value) => value,
+        Err(e) => {
+            println!("ERROR: {:?}", e);
+            exit(1);
+        },
+    };
+
+    for (pos, name) in pin_config.names.iter().enumerate() {
+        if pos == 0 {
+            println!("| {:<10} | {:<10} | {:<10} | {:<10} | {:<10} | {:<10} |", 
+                     pin_config.num, 
+                     pin_config.export, 
+                     direction, 
+                     pin_config.active_low, 
+                     name, 
+                     value);
+        } else {
+            println!("| {:<10} | {:<10} | {:<10} | {:<10} | {:<10} | {:<10} |", 
+                     "", 
+                     "", 
+                     "", 
+                     "", 
+                     name, 
+                     "");
+
+        }
+    }
+    print_row_sep(is_last);
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -7,3 +7,4 @@ pub mod gpio_write;
 pub mod gpio_unexport;
 pub mod gpio_unexportall;
 pub mod gpio_poll;
+pub mod gpio_status;

--- a/src/main.rs
+++ b/src/main.rs
@@ -218,7 +218,13 @@ fn main() {
             };
             gpio_unexportall::main(&cfg, &unexportall_options);
         }
-        ("status", Some(_)) => {}
+        ("status", Some(m)) => {
+            let status_options = GpioStatusOptions {
+                gpio_opts: gpio_options,
+                pin: m.value_of("pin").map(|pin| String::from(pin)),
+            };
+            gpio_status::main(&cfg, &status_options);
+        }
         _ => {}
     }
 }


### PR DESCRIPTION
The status command takes an optional pin argument.  If specified
it will print the GPIO number, export status, direction, active low
status, names, and value.  If the pin argument is not specified it
will print all of the above for every pin that is configured.

@posborne  Be gentle, I'm out of practice on the Rust...