### PR TITLE
license: fixup ownership in license headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,7 @@ support, etc.
 ## License
 
 ```
-Copyright (c) 2016, Paul Osborne <ospbau@gmail.com>
+Copyright (c) 2016, The gpio-utils Authors.
 
 Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
 http://www.apache.org/license/LICENSE-2.0> or the MIT license

--- a/src/commands/gpio_export.rs
+++ b/src/commands/gpio_export.rs
@@ -1,4 +1,10 @@
-// Copyright (C) 2016, The Gpio Util Project Developers.
+// Copyright (c) 2016, The gpio-utils Authors.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/license/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option.  This file may not be copied, modified, or distributed
+// except according to those terms.
 
 use options::GpioExportOptions;
 use config::GpioConfig;

--- a/src/commands/gpio_exportall.rs
+++ b/src/commands/gpio_exportall.rs
@@ -1,4 +1,10 @@
-// Copyright (C) 2016, Paul Osborne <osbpau@gmail.com>
+// Copyright (c) 2016, The gpio-utils Authors.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/license/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option.  This file may not be copied, modified, or distributed
+// except according to those terms.
 
 use options::GpioExportAllOptions;
 use config::GpioConfig;

--- a/src/commands/gpio_poll.rs
+++ b/src/commands/gpio_poll.rs
@@ -1,4 +1,10 @@
-// Copyright (C) 2016, The gpio-utils Authors
+// Copyright (c) 2016, The gpio-utils Authors.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/license/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option.  This file may not be copied, modified, or distributed
+// except according to those terms.
 
 use options::GpioPollOptions;
 use config::GpioConfig;

--- a/src/commands/gpio_read.rs
+++ b/src/commands/gpio_read.rs
@@ -1,4 +1,10 @@
-// Copyright (C) 2016, Paul Osborne <osbpau@gmail.com>
+// Copyright (c) 2016, The gpio-utils Authors.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/license/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option.  This file may not be copied, modified, or distributed
+// except according to those terms.
 
 use options::GpioReadOptions;
 use config::GpioConfig;

--- a/src/commands/gpio_status.rs
+++ b/src/commands/gpio_status.rs
@@ -1,3 +1,11 @@
+// Copyright (c) 2016, The gpio-utils Authors.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/license/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option.  This file may not be copied, modified, or distributed
+// except according to those terms.
+
 use options::GpioStatusOptions;
 use config::GpioConfig;
 use config::PinConfig;

--- a/src/commands/gpio_unexport.rs
+++ b/src/commands/gpio_unexport.rs
@@ -1,4 +1,10 @@
-// Copyright (C) 2016, The gpio-utils Authors
+// Copyright (c) 2016, The gpio-utils Authors.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/license/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option.  This file may not be copied, modified, or distributed
+// except according to those terms.
 
 use options::GpioUnexportOptions;
 use config::GpioConfig;

--- a/src/commands/gpio_unexportall.rs
+++ b/src/commands/gpio_unexportall.rs
@@ -1,4 +1,10 @@
-// Copyright (C) 2016, The gpio-utils Authors
+// Copyright (c) 2016, The gpio-utils Authors.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/license/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option.  This file may not be copied, modified, or distributed
+// except according to those terms.
 
 use options::GpioUnexportAllOptions;
 use config::GpioConfig;

--- a/src/commands/gpio_write.rs
+++ b/src/commands/gpio_write.rs
@@ -1,4 +1,10 @@
-// Copyright (C) 2016, The gpio-utils Authors
+// Copyright (c) 2016, The gpio-utils Authors.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/license/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option.  This file may not be copied, modified, or distributed
+// except according to those terms.
 
 use options::GpioWriteOptions;
 use config::GpioConfig;

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,4 +1,10 @@
-// Copyright (C) 2016, Paul Osborne <osbpau@gmail.com>
+// Copyright (c) 2016, The gpio-utils Authors.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/license/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option.  This file may not be copied, modified, or distributed
+// except according to those terms.
 
 pub mod gpio_read;
 pub mod gpio_export;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,10 @@
-// Copyright (C) 2016, Paul Osborne <osbpau@gmail.com>
+// Copyright (c) 2016, The gpio-utils Authors.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/license/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option.  This file may not be copied, modified, or distributed
+// except according to those terms.
 
 use glob::glob;
 use rustc_serialize::{Decodable, Decoder};

--- a/src/export.rs
+++ b/src/export.rs
@@ -1,4 +1,10 @@
-// Copyright (C) 2016, The gpio-utils Authors
+// Copyright (c) 2016, The gpio-utils Authors.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/license/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option.  This file may not be copied, modified, or distributed
+// except according to those terms.
 
 use std::path;
 use std::os::unix::fs as unix_fs;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,10 @@
-// Copyright (C) 2016, Paul Osborne <osbpau@gmail.com>
+// Copyright (c) 2016, The gpio-utils Authors.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/license/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option.  This file may not be copied, modified, or distributed
+// except according to those terms.
 
 #[macro_use]
 extern crate sysfs_gpio;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,10 @@
-// Copyright (C) 2016, Paul Osborne <osbpau@gmail.com>
+// Copyright (c) 2016, The gpio-utils Authors.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/license/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option.  This file may not be copied, modified, or distributed
+// except according to those terms.
 
 extern crate gpio_utils;
 extern crate clap;

--- a/src/options.rs
+++ b/src/options.rs
@@ -1,4 +1,10 @@
-// Copyright (C) 2016, Paul Osborne <osbpau@gmail.com>
+// Copyright (c) 2016, The gpio-utils Authors.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/license/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option.  This file may not be copied, modified, or distributed
+// except according to those terms.
 
 #[derive(Debug)]
 pub struct GpioOptions {


### PR DESCRIPTION
The copyright for files is shared between all the developers
that have contributed to the project, not just me.  This
change does not modify the license itself at all.

Signed-off-by: Paul Osborne <osbpau@gmail.com>