### PR TITLE
ci: fix nightly builds by disabling clippy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,4 @@ rust:
 
 script:
   - cargo test
-  - |
-      if [ "${TRAVIS_RUST_VERSION}" = "nightly" ]; then
-         cargo install --git https://github.com/arcnmx/cargo-clippy
-         cargo clippy --lib --features lints
-         cargo clippy --bin gpio --features lints
-      fi
   - cargo doc


### PR DESCRIPTION
Although nice to have clippy going, it is causing build failures
right now.  Disabling until I have time to figure out how to get
it going again.

CC @nastevens @varzac 