### PR TITLE
export: fix active_low operation when using direction high/low

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "gpio-utils"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["Paul Osborne <osbpau@gmail.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"

--- a/src/export.rs
+++ b/src/export.rs
@@ -125,15 +125,15 @@ pub fn export(pin_config: &PinConfig, symlink_root: Option<&str>) -> Result<()> 
         // create root directory if not exists
         fs::create_dir_all(symroot)?;
 
+        // set active low
+        pin_config
+            .get_pin()
+            .set_active_low(pin_config.active_low)?;
+
         // set the pin direction
         pin_config
             .get_pin()
             .set_direction(pin_config.direction)?;
-
-        // set active low directio
-        pin_config
-            .get_pin()
-            .set_active_low(pin_config.active_low)?;
 
         // create symlink for each name
         for name in &pin_config.names {


### PR DESCRIPTION
Previously, we set the pin direction from the config on the pin after
we set the direction.  When high/low were used to specify an output with
an initial state this leads to the logic on export being inverted from
subsequent operations.

Fixes #26