### PR TITLE
Add wg email as first entry in authors list

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,8 @@
 [package]
 name = "gpio-utils"
 version = "0.3.0"
-authors = ["Paul Osborne <osbpau@gmail.com>"]
+authors = ["Rust Embedded WG Linux Team <embedded-linux@teams.rust-embedded.org>",
+           "Paul Osborne <osbpau@gmail.com>"]
 license = "MIT/Apache-2.0"
 readme = "README.md"
 homepage = "https://github.com/rust-embedded/gpio-utils"


### PR DESCRIPTION
If this general pattern looks good it can be copied over to other repos.  I could also get rid of my own email since I am in the WG.  In some cases there are other contributor emails outside of the WG and I'm not sure of the etiquette around whether they should be dropped.