### PR TITLE
Add support for passing most common CLI options via enviromment variables

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ Rust applications or any other applications.
 """
 
 [dependencies]
-clap = { version = "4.5.48", features = ["derive"] }
+clap = { version = "4.5.48", features = ["derive", "env"] }
 sysfs_gpio = "0.6.2"
 toml = { version = "<=0.9.6", default-features = false, features = ["parse", "serde"] }
 glob = "0.3.3"

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ use gpio_utils::config::{self, GpioConfig};
 use gpio_utils::options::*;
 use std::process;
 
-#[derive(Parser)]
+#[derive(Debug, Parser)]
 #[command(
     name = "GPIO Utils",
     version,
@@ -26,7 +26,7 @@ struct Cli {
     command: Commands,
 }
 
-#[derive(Subcommand)]
+#[derive(Debug, Subcommand)]
 enum Commands {
     /// Read the value of a GPIO Input
     Read {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,6 +12,9 @@ use gpio_utils::config::{self, GpioConfig};
 use gpio_utils::options::*;
 use std::process;
 
+pub const CONFIG_ENV_VAR: &str = "GPIO_UTILS_CONFIG";
+pub const SYMLINK_ROOT_ENV_VAR: &str = "GPIO_UTILS_SYMLINK_ROOT";
+
 #[derive(Debug, Parser)]
 #[command(
     name = "GPIO Utils",
@@ -19,8 +22,8 @@ use std::process;
     about = "Read, Write, and Configure GPIOs"
 )]
 struct Cli {
-    /// additional configuration to use
-    #[arg(short, long = "config", value_name = "FILE")]
+    /// additional configuration to use (separator ':')
+    #[arg(short, long = "config", value_name = "FILE", num_args = 0.., env = CONFIG_ENV_VAR, value_delimiter = ':')]
     configs: Vec<String>,
     #[command(subcommand)]
     command: Commands,
@@ -56,13 +59,13 @@ enum Commands {
         /// The pin name (or number)
         pin: String,
         /// root directory for export symlinks
-        #[arg(short = 'r', long)]
+        #[arg(short = 'r', long, env = SYMLINK_ROOT_ENV_VAR)]
         symlink_root: Option<String>,
     },
     /// Export all configured GPIOs
     ExportAll {
         /// Export all configured GPIOs
-        #[arg(short = 'r', long)]
+        #[arg(short = 'r', long, env = SYMLINK_ROOT_ENV_VAR)]
         symlink_root: Option<String>,
     },
     /// Export all configured GPIOs
@@ -70,13 +73,13 @@ enum Commands {
         /// The pin name (or number)
         pin: String,
         /// root directory for export symlinks
-        #[arg(short = 'r', long)]
+        #[arg(short = 'r', long, env = SYMLINK_ROOT_ENV_VAR)]
         symlink_root: Option<String>,
     },
     /// Unexport all configured, exported GPIOs
     UnexportAll {
         /// root directory for export symlinks
-        #[arg(short = 'r', long)]
+        #[arg(short = 'r', long, env = SYMLINK_ROOT_ENV_VAR)]
         symlink_root: Option<String>,
     },
     /// Output status of a GPIO or all GPIOs if no pin is specified


### PR DESCRIPTION
I really don't like typing long command lines or constantly editing one. Let's allow to pass the two most commonly used CLI options via environment variables.